### PR TITLE
Ipad Support

### DIFF
--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -1091,7 +1091,7 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
 
     func cameraPermissionsChanged(hasFullAccess: Bool) {
         if hasFullAccess {
-            cameraInputController.setupCaptureSession()
+            cameraInputController.setupCaptureSession(frameSize: view.frame.size)
             toggleMediaPicker(visible: true, animated: false)
         }
     }

--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -640,6 +640,10 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
     private func generateHapticFeedback() {
         feedbackGenerator.notificationOccurred(.success)
     }
+
+    public var confirmButton: UIView? {
+        return (presentedViewController as? MultiEditorViewController)?.currentEditor?.editorView.confirmOrPostButton()
+    }
     
     // MARK: - CameraViewDelegate
 

--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -173,7 +173,9 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
         return controller
     }()
     private lazy var clipsController: MediaClipsEditorViewController = {
-        let controller = MediaClipsEditorViewController(showsAddButton: false)
+        let viewSettings = MediaClipsCollectionView.Settings(showsFadeOutGradient: false)
+        let collectionSettings = MediaClipsCollectionController.Settings(clipsCollectionViewSettings: viewSettings)
+        let controller = MediaClipsEditorViewController(showsAddButton: false, collectionSettings: collectionSettings)
         controller.delegate = self
         return controller
     }()

--- a/Classes/Constants/KanvasEditorDesign.swift
+++ b/Classes/Constants/KanvasEditorDesign.swift
@@ -186,4 +186,43 @@ public struct KanvasEditorDesign {
             }
         )
     }()
+
+    public static var storiesDesign: KanvasEditorDesign = {
+        return KanvasEditorDesign(
+            isVerticalMenu: false,
+            checkmarkImage: KanvasImages.shared.editorConfirmImage,
+            buttonBackgroundColor: .clear,
+            buttonInvertedBackgroundColor: .clear,
+            optionBackgroundColor: .clear,
+            topButtonSize: 49,
+            topSecondaryButtonSize: 36,
+            topButtonInterspace: 30,
+            fakeOptionCellCheckmarkImage: UIImage.imageFromCameraBundle(named: "confirm"),
+            closeGradientImage: UIImage.imageFromCameraBundle(named: "closeGradient"),
+            editorViewCloseImage: UIImage.imageFromCameraBundle(named: "whiteCloseIcon"),
+            editorViewBackImage: UIImage.imageFromCameraBundle(named: "back"),
+            editorViewButtonTopMargin: 24,
+            editorViewButtonBottomMargin: Device.belongsToIPhoneXGroup ? 14 : 19.5,
+            editorViewFakeOptionCellMinSize: 36,
+            editorViewFakeOptionCellMaxSize: 45,
+            editorViewCloseButtonSize: 26.5,
+            editorViewCloseButtonHorizontalMargin: 24,
+            drawingViewUndoImage: UIImage.imageFromCameraBundle(named: "undo"),
+            drawingViewEraserSelectedImage: UIImage.imageFromCameraBundle(named: "eraserSelected"),
+            drawingViewEraserUnselectedImage: UIImage.imageFromCameraBundle(named: "eraserUnselected"),
+            drawingViewMarkerImage: UIImage.imageFromCameraBundle(named: "marker"),
+            drawingViewSharpieImage: UIImage.imageFromCameraBundle(named: "sharpie"),
+            drawingViewPencilImage: UIImage.imageFromCameraBundle(named: "pencil"),
+            drawingViewEyeDropperImage: UIImage.imageFromCameraBundle(named: "eyeDropper"),
+            editorTextViewFontImage: UIImage.imageFromCameraBundle(named: "font"),
+            editorTextViewAlignmentImage: [
+                .left: UIImage.imageFromCameraBundle(named: "leftAlignment"),
+                .center: UIImage.imageFromCameraBundle(named: "centerAlignment"),
+                .right: UIImage.imageFromCameraBundle(named: "rightAlignment"),
+            ],
+            editorTextViewHighlightImage: { selected in
+                return selected ? UIImage.imageFromCameraBundle(named: "highlightSelected") : UIImage.imageFromCameraBundle(named: "highlightUnselected")
+            }
+        )
+    }()
 }

--- a/Classes/Editor/EditorView.swift
+++ b/Classes/Editor/EditorView.swift
@@ -347,7 +347,7 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
 
             let bottomConstraint: NSLayoutConstraint
             let topConstraint: NSLayoutConstraint
-            if Device.belongsToIPhoneXGroup {
+            if Device.belongsToIPhoneXGroup || Device.isIPad {
                 bottomConstraint = playerView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
                 topConstraint = playerView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor)
             } else {

--- a/Classes/Editor/MultiEditor/MultiEditorViewController.swift
+++ b/Classes/Editor/MultiEditor/MultiEditorViewController.swift
@@ -76,7 +76,7 @@ class MultiEditorViewController: UIViewController {
 
     private var exportingEditors: [EditorViewController]?
 
-    private weak var currentEditor: EditorViewController?
+    private(set) weak var currentEditor: EditorViewController?
 
     init(settings: CameraSettings,
          frames: [Frame],

--- a/Classes/Editor/MultiEditor/MultiEditorViewController.swift
+++ b/Classes/Editor/MultiEditor/MultiEditorViewController.swift
@@ -16,7 +16,9 @@ protocol MultiEditorComposerDelegate: EditorControllerDelegate {
 
 class MultiEditorViewController: UIViewController {
     private lazy var clipsController: MediaClipsEditorViewController = {
-        let clipsEditor = MediaClipsEditorViewController(showsAddButton: true)
+        let collectionViewSettings = MediaClipsCollectionView.Settings(showsFadeOutGradient: false)
+        let collectionSettings = MediaClipsCollectionController.Settings(clipsCollectionViewSettings: collectionViewSettings)
+        let clipsEditor = MediaClipsEditorViewController(showsAddButton: true, collectionSettings: collectionSettings)
         clipsEditor.delegate = self
         clipsEditor.view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
         return clipsEditor

--- a/Classes/Editor/Shared/ColorCollection/ColorCollectionCell.swift
+++ b/Classes/Editor/Shared/ColorCollection/ColorCollectionCell.swift
@@ -73,8 +73,8 @@ final class ColorCollectionCell: UICollectionViewCell {
         circleView.accessibilityIdentifier = "Color Cell View"
         
         NSLayoutConstraint.activate([
-            circleView.centerXAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.centerXAnchor),
-            circleView.centerYAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.centerYAnchor),
+            circleView.centerXAnchor.constraint(equalTo: contentView.layoutMarginsGuide.centerXAnchor),
+            circleView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             circleView.heightAnchor.constraint(equalToConstant: ColorCollectionCellConstants.circleDiameter),
             circleView.widthAnchor.constraint(equalToConstant: ColorCollectionCellConstants.circleDiameter)
         ])

--- a/Classes/Editor/Text/EditorTextController.swift
+++ b/Classes/Editor/Text/EditorTextController.swift
@@ -285,6 +285,9 @@ final class EditorTextController: UIViewController, EditorTextViewDelegate, Colo
     // This method is called inside the keyboard animation,
     // so any UI change made here will be animated.
     @objc func keyboardWillHide(notification: NSNotification) {
+        if isHiding == false && textView.alpha != 0 {
+            didConfirmText()
+        }
         textView.moveToolsDown()
     }
     
@@ -336,13 +339,17 @@ final class EditorTextController: UIViewController, EditorTextViewDelegate, Colo
             self.textView.startWriting()
         })
     }
-    
+
+    /// A flag to indicate whether we're in the process of hiding. This is used in `keyboardWillHide` to determine whether to confirm the text.
+    private var isHiding = false
     
     /// Makes the view disappear
     private func hide() {
         textView.endWriting()
+        isHiding = true
         UIView.animate(withDuration: Constants.animationDuration) {
             self.textView.alpha = 0
+            self.isHiding = false
         }
     }
     

--- a/Classes/MediaClips/MediaClipsCollectionController.swift
+++ b/Classes/MediaClips/MediaClipsCollectionController.swift
@@ -34,7 +34,7 @@ private struct MediaClipsCollectionControllerConstants {
 
 /// Controller for handling the media clips collection.
 final class MediaClipsCollectionController: UIViewController, UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
-    private lazy var mediaClipsCollectionView = MediaClipsCollectionView()
+    private lazy var mediaClipsCollectionView = MediaClipsCollectionView(settings: settings.clipsCollectionViewSettings)
 
     private var clips: [MediaClip]
     private var draggingClipIndex: IndexPath?
@@ -42,8 +42,15 @@ final class MediaClipsCollectionController: UIViewController, UICollectionViewDe
 
     weak var delegate: MediaClipsCollectionControllerDelegate?
 
-    init() {
+    struct Settings {
+        let clipsCollectionViewSettings: MediaClipsCollectionView.Settings
+    }
+
+    private let settings: Settings
+
+    init(settings: Settings) {
         clips = []
+        self.settings = settings
         super.init(nibName: .none, bundle: .none)
     }
 

--- a/Classes/MediaClips/MediaClipsCollectionView.swift
+++ b/Classes/MediaClips/MediaClipsCollectionView.swift
@@ -18,9 +18,16 @@ final class MediaClipsCollectionView: UIView {
     static let height = MediaClipsCollectionViewConstants.height
     let collectionView: UICollectionView
     let fadeOutGradient = CAGradientLayer()
+
+    struct Settings {
+        let showsFadeOutGradient: Bool
+    }
+
+    private let settings: Settings
         
-    init() {
+    init(settings: Settings) {
         collectionView = createCollectionView()
+        self.settings = settings
 
         super.init(frame: .zero)
 
@@ -49,7 +56,9 @@ extension MediaClipsCollectionView {
     private func setUpViews() {
         collectionView.add(into: self)
         collectionView.clipsToBounds = false
-        setFadeOutGradient()
+        if settings.showsFadeOutGradient {
+            setFadeOutGradient()
+        }
     }
     
     private func setFadeOutGradient() {

--- a/Classes/MediaClips/MediaClipsEditorViewController.swift
+++ b/Classes/MediaClips/MediaClipsEditorViewController.swift
@@ -50,9 +50,9 @@ final class MediaClipsEditorViewController: UIViewController, MediaClipsCollecti
     /// This needs to be dynamic because it will be observed
     @objc private(set) dynamic var hasClips: Bool = false
 
-    init(showsAddButton: Bool = false) {
+    init(showsAddButton: Bool = false, collectionSettings: MediaClipsCollectionController.Settings) {
         editorView = MediaClipsEditorView(showsAddButton: showsAddButton)
-        collectionController = MediaClipsCollectionController()
+        collectionController = MediaClipsCollectionController(settings: collectionSettings)
         super.init(nibName: .none, bundle: .none)
         collectionController.delegate = self
         editorView.delegate = self

--- a/Classes/Settings/CameraSettings.swift
+++ b/Classes/Settings/CameraSettings.swift
@@ -309,6 +309,9 @@ public struct CameraFeatures {
     /// Animate the movement of control in the editor
     public var animateEditorControls: Bool = DefaultCameraSettings.animateEditorControls
 
+    /// Whether to show a shadow to the sides of the media clips
+    public var showShadowOverMediaClips: Bool = DefaultCameraSettings.showShadowOverMediaClips
+
     /// The Font Selector button uses the currently selected font for its label
     public var fontSelectorUsesFont: Bool = DefaultCameraSettings.fontFamilyUsesFont
 
@@ -377,4 +380,5 @@ private struct DefaultCameraSettings {
     static let gifCameraShouldStartGIFMaker: Bool = false
     static let fontFamilyUsesFont: Bool = false
     static let animateEditorControls: Bool = true
+    static let showShadowOverMediaClips: Bool = true
 }


### PR DESCRIPTION
Adds basic iPad support to Kanvas.

- Handles rotation by refreshing the capture session when device rotates.
- Uses the same constraints as the non-home button iPhones for positioning preview
- Adds a new `KanvasEditorDesign.storiesDesign` for tweaking button sizing.
- Adds a new `CameraSettings.showShadowOverMediaClips` flag for disabling the shadow on either side of the media clips view.
